### PR TITLE
optimize read_dir and init_children_map

### DIFF
--- a/src/client/filesystem.rs
+++ b/src/client/filesystem.rs
@@ -395,26 +395,6 @@ impl FuseFilesystem for Filesystem {
         })
     }
 
-    /*fn destroy(&mut self, _req: &Request) {
-        let uuid = self
-            .uuid
-            .as_ref()
-            .expect("uuid should initialize")
-            .to_string();
-
-        task::block_on(async {
-            let req = TonicRequest::new(LogoutRequest { uuid });
-
-            info!("sending logout request");
-
-            if let Err(err) = self.rpc_client.logout(req).await {
-                error!("logout failed {}", err)
-            }
-
-            info!("logout success")
-        })
-    }*/
-
     fn lookup(&mut self, req: &Request, parent: u64, name: &OsStr, reply: ReplyEntry) {
         let name = match name.to_str() {
             None => {

--- a/src/server/filesystem/entry.rs
+++ b/src/server/filesystem/entry.rs
@@ -10,19 +10,10 @@ use super::file::File;
 use super::inode::Inode;
 use super::SetAttr;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Entry {
     Dir(Arc<Dir>),
     File(Arc<File>),
-}
-
-impl Clone for Entry {
-    fn clone(&self) -> Self {
-        match self {
-            Entry::Dir(dir) => Entry::Dir(dir.clone()),
-            Entry::File(file) => Entry::File(file.clone()),
-        }
-    }
 }
 
 impl Entry {


### PR DESCRIPTION
make read_dir and init_children_map internal concurrent, it will improve
performance when dir children is a lot. When has 1094 children, the
performance improve more than 20%