### PR TITLE
add mount.rfs support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
+checksum = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
 dependencies = [
  "libc",
 ]
@@ -1394,18 +1394,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3711fd1c4e75b3eff12ba5c40dba762b6b65c5476e8174c1a664772060c49bf"
+checksum = "f0570dc61221295909abdb95c739f2e74325e14293b2026b0a7e195091ec54ae"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2b85ba4c9aa32dd3343bd80eb8d22e9b54b7688c17ea3907f236885353b233"
+checksum = "227362df41d566be41a28f64401e07a043157c21c14b9785a0d8e256f940a8fd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a03abb7c9b93ae229356151a083d26218c0358866a2a59d4280c856e9482e6"
+checksum = "991d0a1a3e790c835fd54ab41742a59251338d8c7577fe7d7f0170c7072be708"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
+checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
 
 [[package]]
 name = "byteorder"
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5c295d1c0c68e4e42003d75f908f5e16a1edd1cbe0b0d02e4dc2006a384f47"
+checksum = "7938e6aa2a31df4e21f224dc84704bd31c089a6d1355c535b03667371cccc843"
 dependencies = [
  "bytes",
  "fnv",
@@ -494,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
+checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
  "bytes",
  "fnv",
@@ -587,9 +587,9 @@ checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
 name = "js-sys"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb931d43e71f560c81badb0191596562bafad2be06a3f9025b845c847c60df5"
+checksum = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -714,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97fbd5d00e0e37bfb10f433af8f5aaf631e739368dc9fc28286ca81ca4948dc"
+checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
 
 [[package]]
 name = "net2"
@@ -1055,9 +1055,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8900ebc1363efa7ea1c399ccc32daed870b4002651e0bed86e72d501ebbe0048"
+checksum = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1111,13 +1111,14 @@ dependencies = [
 
 [[package]]
 name = "rfs-client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-std",
  "futures-util",
  "lazy_static",
  "log",
+ "nix",
  "rfs",
  "serde",
  "serde_yaml",
@@ -1128,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "rfs-server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-signals",
@@ -1149,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.11"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741ba1704ae21999c00942f9f5944f801e977f54302af346b596287599ad1862"
+checksum = "1ba5a8ec64ee89a76c98c549af81ff14813df09c3e6dc4766c3856da48597a0c"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1262,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.48"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
+checksum = "78a7a12c167809363ec3bd7329fc0a3369056996de43c4b37ef3cd54a6ce4867"
 dependencies = [
  "itoa",
  "ryu",
@@ -1597,14 +1598,15 @@ checksum = "a35d656f2638b288b33495d1053ea74c40dc05ec0b92084dd71ca5566c4ed1dc"
 
 [[package]]
 name = "tower-limit"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4030a1dc1ab99ec6fc9475fc18c62f6cc4da035d370fcbd22fe342f9dd16cd"
+checksum = "92c3040c5dbed68abffaa0d4517ac1a454cd741044f33ab0eefab6b8d1361404"
 dependencies = [
  "futures-core",
  "pin-project",
  "tokio",
  "tower-layer",
+ "tower-load",
  "tower-service",
 ]
 
@@ -1818,9 +1820,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.59"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3557c397ab5a8e347d434782bcd31fc1483d927a6826804cec05cc792ee2519d"
+checksum = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1828,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.59"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0da9c9a19850d3af6df1cb9574970b566d617ecfaf36eb0b706b6f3ef9bd2f8"
+checksum = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1843,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.59"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6fde1d36e75a714b5fe0cffbb78978f222ea6baebb726af13c78869fdb4205"
+checksum = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1853,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.59"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bda4168030a6412ea8a047e27238cadf56f0e53516e1e83fec0a8b7c786f6d"
+checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1866,15 +1868,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.59"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc9f36ad51f25b0219a3d4d13b90eb44cd075dff8b6280cca015775d7acaddd8"
+checksum = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
 
 [[package]]
 name = "web-sys"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721c6263e2c66fd44501cc5efbfa2b7dfa775d13e4ea38c46299646ed1f9c70a"
+checksum = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/rfs-client/Cargo.toml
+++ b/rfs-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rfs-client"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Sherlock Holo <sherlockya@gmail.com>"]
 edition = "2018"
 
@@ -17,6 +17,7 @@ log = "0.4"
 tonic = { version = "0.1", features = ["tls"] }
 futures-util = "0.3"
 lazy_static = "1"
+nix = "0.17"
 
 [dependencies.tokio]
 version = "0.2"

--- a/rfs-client/src/lib.rs
+++ b/rfs-client/src/lib.rs
@@ -1,9 +1,16 @@
+use std::convert::TryInto;
+use std::env::args;
+use std::ffi::OsString;
 use std::path::PathBuf;
 use std::str::FromStr;
 
 use anyhow::{Context, Result};
 use async_std::fs;
+use async_std::path::Path;
+use async_std::task;
 use log::info;
+use nix::unistd;
+use nix::unistd::ForkResult;
 use serde::Deserialize;
 use structopt::StructOpt;
 use tonic::transport::{Certificate, ClientTlsConfig, Identity, Uri};
@@ -23,19 +30,116 @@ pub struct Config {
 }
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "rfs-client", about = "rfs client.")]
+#[structopt(about = "mount a rfs filesystem")]
 pub struct Argument {
     #[structopt(short, long, default_value = "/etc/rfs/client.yml", parse(from_os_str))]
-    config: PathBuf,
+    pub config: PathBuf,
 }
 
-pub async fn run(handle: tokio::runtime::Handle) -> Result<()> {
-    let args = Argument::from_args();
+#[derive(Debug, Eq, PartialEq)]
+pub enum RunMode {
+    Foreground,
+    Background,
+}
 
-    let cfg_data = fs::read(&args.config).await?;
+#[derive(Debug, StructOpt)]
+#[structopt(about = "mount a rfs filesystem")]
+pub struct MountArgument {
+    #[structopt(help = "server addr, such as https://example.com")]
+    server_addr: String,
 
-    let cfg: Config = serde_yaml::from_slice(&cfg_data)?;
+    #[structopt(help = "mount point")]
+    mount_point: String,
 
+    #[structopt(
+        short,
+        long,
+        help = "cert=<path> and key=<path> are required, debug, compress, debug_ca=<path> and background is optional"
+    )]
+    options: String,
+}
+
+impl TryInto<(Config, RunMode)> for MountArgument {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> Result<(Config, RunMode), Self::Error> {
+        let server_addr = self.server_addr;
+        let mount_path = PathBuf::from(self.mount_point);
+
+        let mut cert = None;
+        let mut key = None;
+        let mut debug = None;
+        let mut compress = None;
+        let mut debug_ca = None;
+        let mut mode = RunMode::Background;
+
+        for opt in self.options.split(",") {
+            if opt.starts_with("cert") {
+                cert = Some(opt.replace("cert=", ""));
+            } else if opt.starts_with("key") {
+                key = Some(opt.replace("key=", ""));
+            } else if opt == "debug" {
+                debug = Some(true)
+            } else if opt == "compress" {
+                compress = Some(true);
+            } else if opt == "debug_ca" {
+                debug_ca = Some(PathBuf::from(opt.replace("debug_ca=", "")));
+            } else if opt == "foreground" {
+                mode = RunMode::Foreground;
+            }
+        }
+
+        let cert = cert.ok_or(anyhow::anyhow!("cert is miss"))?.into();
+        let key = key.ok_or(anyhow::anyhow!("key is miss"))?.into();
+
+        Ok((
+            Config {
+                server_addr,
+                mount_path,
+                cert_path: cert,
+                key_path: key,
+                debug,
+                compress,
+                debug_ca_path: debug_ca,
+            },
+            mode,
+        ))
+    }
+}
+
+pub fn run() -> Result<()> {
+    let program_name = args().nth(0).map_or(String::from(""), |name| name);
+
+    let program_name = Path::new(&program_name)
+        .file_name()
+        .map_or(OsString::new(), |filename| filename.to_os_string());
+
+    let cfg = if program_name == "mount.rfs" {
+        let args = MountArgument::from_args();
+
+        let (cfg, mode): (Config, RunMode) = args.try_into()?;
+
+        if mode == RunMode::Background {
+            if let ForkResult::Child = unistd::fork()? {
+                cfg
+            } else {
+                return Ok(());
+            }
+        } else {
+            cfg
+        }
+    } else {
+        let args = Argument::from_args();
+
+        let cfg_data = std::fs::read(&args.config)?;
+
+        serde_yaml::from_slice(&cfg_data)?
+    };
+
+    task::block_on(enter_tokio(Box::pin(inner_run(cfg))))
+}
+
+pub async fn inner_run(cfg: Config) -> Result<()> {
     let debug = if let Some(debug) = cfg.debug {
         debug
     } else {
@@ -70,7 +174,7 @@ pub async fn run(handle: tokio::runtime::Handle) -> Result<()> {
         false
     };
 
-    let filesystem = Filesystem::new(uri, tls_config, handle, compress).await?;
+    let filesystem = Filesystem::new(uri, tls_config, get_tokio_handle(), compress).await?;
 
     filesystem.mount(&cfg.mount_path).await?;
 

--- a/rfs-client/src/lib.rs
+++ b/rfs-client/src/lib.rs
@@ -16,10 +16,10 @@ use structopt::StructOpt;
 use tonic::transport::{Certificate, ClientTlsConfig, Identity, Uri};
 
 use rfs::{log_init, Filesystem};
-pub use tokio_runtime::{enter_tokio, get_tokio_handle};
+use tokio_runtime::{enter_tokio, get_tokio_handle};
 
 #[derive(Debug, Deserialize)]
-pub struct Config {
+struct Config {
     mount_path: PathBuf,
     server_addr: String,
     cert_path: PathBuf,
@@ -31,20 +31,20 @@ pub struct Config {
 
 #[derive(Debug, StructOpt)]
 #[structopt(about = "mount a rfs filesystem")]
-pub struct Argument {
+struct Argument {
     #[structopt(short, long, default_value = "/etc/rfs/client.yml", parse(from_os_str))]
-    pub config: PathBuf,
+    config: PathBuf,
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub enum RunMode {
+enum RunMode {
     Foreground,
     Background,
 }
 
 #[derive(Debug, StructOpt)]
 #[structopt(about = "mount a rfs filesystem")]
-pub struct MountArgument {
+struct MountArgument {
     #[structopt(help = "server addr, such as https://example.com")]
     server_addr: String,
 
@@ -139,7 +139,7 @@ pub fn run() -> Result<()> {
     task::block_on(enter_tokio(Box::pin(inner_run(cfg))))
 }
 
-pub async fn inner_run(cfg: Config) -> Result<()> {
+async fn inner_run(cfg: Config) -> Result<()> {
     let debug = if let Some(debug) = cfg.debug {
         debug
     } else {

--- a/rfs-client/src/main.rs
+++ b/rfs-client/src/main.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
 
-use rfs_client::{enter_tokio, get_tokio_handle, run};
+use rfs_client::run;
 
-#[async_std::main]
-async fn main() -> Result<()> {
-    enter_tokio(Box::pin(run(get_tokio_handle()))).await
+fn main() -> Result<()> {
+    run()
 }

--- a/rfs-server/Cargo.toml
+++ b/rfs-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rfs-server"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Sherlock Holo <sherlockya@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
now client support `mount.rfs`. When install rfs-client as mount.rfs or soft link to right way, such as `/usr/sbin/`, call `mount -t rfs` like normal mount such as `mount -t btrfs`